### PR TITLE
Make populate fallthrough to default with undefined x-variable

### DIFF
--- a/bin/populate.js
+++ b/bin/populate.js
@@ -111,9 +111,8 @@ function apply(v, exception, schema, type, object, property) {
     if (object[property] === undefined) {
         const options = v.options;
         const map = v.map;
-        if (options.variables && schema.hasOwnProperty('x-variable') && map.hasOwnProperty(schema['x-variable'])) {
-            const value = map[schema['x-variable']];
-            if (value !== undefined) object[property] = value;
+        if (options.variables && schema.hasOwnProperty('x-variable') && map.hasOwnProperty(schema['x-variable']) && map[schema['x-variable']] !== undefined) {
+            object[property] = map[schema['x-variable']];
 
         } else if (options.templates && type === 'string' && schema.hasOwnProperty('x-template')) {
             const value = v.injector(schema['x-template'], map);
@@ -191,9 +190,8 @@ function populate(version, schema, params, value, options) {
 
             // if there is no value then attempt to populate one
             if (data.value === undefined) {
-                if (options.variables && schema.hasOwnProperty('x-variable') && params.hasOwnProperty(schema['x-variable'])) {
-                    const value = params[schema['x-variable']];
-                    if (value !== undefined) data.value = value;
+                if (options.variables && schema.hasOwnProperty('x-variable') && params.hasOwnProperty(schema['x-variable']) && params[schema['x-variable']] !== undefined) {
+                    data.value = params[schema['x-variable']];
 
                 } else if (options.templates && type === 'string' && schema.hasOwnProperty('x-template')) {
                     const value = injector(schema['x-template'], params);

--- a/bin/schemas.js
+++ b/bin/schemas.js
@@ -17,7 +17,7 @@
 'use strict';
 const Exception = require('./exception');
 const util      = require('./util');
-const Parse     = require('./parse');
+const Parse     = require('./parse-value');
 const Validate  = require('./validate');
 
 const rxExtension = /^x-.+/;

--- a/test/populate.test.js
+++ b/test/populate.test.js
@@ -63,6 +63,16 @@ describe('#populate', () => {
             expect(value).to.equal(5);
         });
 
+        it('default and x-variable 3', () => {
+            const value = enforcer.populate({ type: 'number', default: 5, 'x-variable': 'myNumber' }, {});
+            expect(value).to.equal(5);
+        });
+
+        it('default and x-variable 4', () => {
+            const value = enforcer.populate({ type: 'number', default: 5, 'x-variable': 'myNumber' }, { myNumber: undefined });
+            expect(value).to.equal(5);
+        });
+
         it('does not format', () => {
             const enforcer = new Enforcer(definition);
             const date = new Date();


### PR DESCRIPTION
Resolves https://github.com/byu-oit/openapi-enforcer/issues/5.

Also includes a change to `require('./parse-value')` because tests wouldn't run without it.