### PR TITLE
Pass requestBodyAllowedMethods as config variable

### DIFF
--- a/examples/check-definition-for-errors.js
+++ b/examples/check-definition-for-errors.js
@@ -17,10 +17,10 @@
 'use strict';
 
 const Enforcer = require('../');
-const errors = Enforcer.errors({
+
+Enforcer({
     openapi: '3.0.0',
     info: {
         title: "My API"
     }
-});
-console.log(errors);
+}).then(null,errors => {console.log(errors)});

--- a/examples/request-response.js
+++ b/examples/request-response.js
@@ -94,8 +94,8 @@ const req = enforcer.request({
     path: '/shapes/square?color=red,blue'
 });
 
-const schema = req.operation.
+const schema = req.operation;
 const responseObject = req.operation.responses[200]
 .populate('application/json', {
-    headers:
-})
+    headers: ""
+});

--- a/index.js
+++ b/index.js
@@ -25,12 +25,15 @@ const Result                = require('./src/result');
 const Super                 = require('./src/super');
 const util                  = require('./src/util');
 
+const requestBodyAllowedMethods = { post: true, put: true, options: true, head: true, patch: true };
+
 /**
  * Create an Enforcer instance.
  * @param {string, object} definition
  * @param {object} [options]
  * @param {boolean} [options.hideWarnings=false] Set to true to hide warnings from the console.
  * @param {boolean} [options.fullResult=false] Set to true to get back a full result object with the value, warnings, and errors.
+ * @param {object} [options.internalOptions]
  * @returns {Promise<OpenApiEnforcer>}
  */
 async function Enforcer(definition, options) {
@@ -41,6 +44,9 @@ async function Enforcer(definition, options) {
     options = Object.assign({}, options);
     if (!options.hasOwnProperty('hideWarnings')) options.hideWarnings = false;
     if (!options.hasOwnProperty('fullResult')) options.fullResult = false;
+    if (!options.hasOwnProperty('internalOptions')) options.internalOptions = {};
+
+    if (!options.internalOptions.hasOwnProperty('requestBodyAllowedMethods')) options.internalOptions['requestBodyAllowedMethods'] = requestBodyAllowedMethods;
 
     const refParser = new RefParser();
     definition = util.copy(definition);
@@ -61,7 +67,7 @@ async function Enforcer(definition, options) {
             const validator = major === 2
                 ? Enforcer.v2_0.Swagger
                 : Enforcer.v3_0.OpenApi;
-            [ openapi, exception, warnings ] = validator(definition, refParser);
+            [ openapi, exception, warnings ] = validator(definition, refParser, options.internalOptions);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ async function Enforcer(definition, options) {
     if (!options.hasOwnProperty('fullResult')) options.fullResult = false;
     if (!options.hasOwnProperty('internalOptions')) options.internalOptions = {};
 
-    if (!options.internalOptions.hasOwnProperty('requestBodyAllowedMethods')) options.internalOptions['requestBodyAllowedMethods'] = requestBodyAllowedMethods;
+    if (!options.internalOptions.requestBodyAllowedMethods) options.internalOptions.requestBodyAllowedMethods = requestBodyAllowedMethods;
 
     const refParser = new RefParser();
     definition = util.copy(definition);

--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ async function Enforcer(definition, options) {
     if (!options.hasOwnProperty('fullResult')) options.fullResult = false;
     if (!options.hasOwnProperty('internalOptions')) options.internalOptions = {};
 
-    if (!options.internalOptions.requestBodyAllowedMethods) options.internalOptions.requestBodyAllowedMethods = requestBodyAllowedMethods;
+    if (!options.internalOptions.requestBodyAllowedMethods) {
+        options.internalOptions.requestBodyAllowedMethods = requestBodyAllowedMethods;
+    }
 
     const refParser = new RefParser();
     definition = util.copy(definition);

--- a/src/definition-validator.js
+++ b/src/definition-validator.js
@@ -46,6 +46,7 @@ function childData(parent, key, validator) {
         major: parent.major,
         map: parent.map,
         minor: parent.minor,
+        options: parent.options,
         parent,
         patch: parent.patch,
         plugins: parent.plugins,

--- a/src/enforcers/Operation.js
+++ b/src/enforcers/Operation.js
@@ -23,7 +23,6 @@ const Value         = require('../schema/value');
 
 const rxInteger = /^\d+$/;
 const rxNumber = /^\d+(?:\.\d+)?$/;
-const requestBodyAllowedMethods = { post: true, put: true, options: true, head: true, patch: true };
 
 module.exports = {
     init: function (data) {
@@ -420,7 +419,7 @@ module.exports = {
         }
     },
 
-    validator: function ({ major }) {
+    validator: function ({ major, options }) {
         return {
             type: 'object',
             properties: {
@@ -470,7 +469,7 @@ module.exports = {
                 },
                 requestBody: EnforcerRef('RequestBody', {
                     // for easy unit testing default key to post if there is no parent key
-                    allowed: ({ parent }) => major === 3 && !!requestBodyAllowedMethods[parent.key || 'post']
+                    allowed: ({ parent }) => major === 3 && !!options.requestBodyAllowedMethods[parent.key || 'post']
                 }),
                 responses: EnforcerRef('Responses', { required: true }),
                 schemes: {

--- a/src/super.js
+++ b/src/super.js
@@ -33,9 +33,9 @@ function createConstructor(version, name, enforcer) {
 
     // build the named constructor
     const F = new Function('build',
-        `const F = function ${name} (definition, refParser) {
-            if (!(this instanceof F)) return new F(definition, refParser)
-            return build(this, definition, refParser)
+        `const F = function ${name} (definition, refParser, options) {
+            if (!(this instanceof F)) return new F(definition, refParser, options)
+            return build(this, definition, refParser, options)
         }
         return F`
     )(build);
@@ -91,7 +91,7 @@ function createConstructor(version, name, enforcer) {
         });
     }
 
-    function build (result, definition, refParser) {
+    function build (result, definition, refParser, options) {
         const isStart = !definitionValidator.isValidatorState(definition);
 
         // validate the definition
@@ -117,6 +117,7 @@ function createConstructor(version, name, enforcer) {
                 staticData,
                 validator: enforcer.validator,
                 warn: Exception('One or more warnings exist in the ' + name + ' definition'),
+                options: options
             };
             data.root = data;
 


### PR DESCRIPTION
Hello!
We at the company use your libraries: openapi-enforcer and openapi-enforcer-middleware.
We need the ability to pass parameters in the body of the delete request.
To solve this problem, I implemented the transfer of the requestBodyAllowedMethods parameter in the config variable.
Please confirm this pull request
Thanks!