### PR TITLE
Marfarin internal options

### DIFF
--- a/docs-src/api/index.md
+++ b/docs-src/api/index.md
@@ -22,6 +22,13 @@ This function will dereference your OAS document, validate it, produce warnings 
 | --------- | ----------- | ---- | ------- |
 | fullResult | Get back a full [Enforcer Result](./enforcer-result.md) object. Enabling this will also cause warnings not to output to the console. | `boolean` | `false` |
 | hideWarnings | Do not log warning messages to the console when validating your OAS document. If the `fullResult` option is set to `true` then warnings will not show regardless of this setting. | `boolean` | `false` |
+| componentOptions | Options to pass along to the enforcer components | `object` | See [Component Option](#component-options) |
+
+**Component Options**
+
+| Property | Description | Type  | Default |
+| --------- | ----------- | ---- | ------- |
+| requestBodyAllowedMethods | An `object` specifying which request methods to allow (or disallow) a request body for. The object you provide here will merge with the default value. | `object` | ` { post: true, put: true, options: true, head: true, patch: true } `
     
 **Returns:** A Promise
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -112,6 +112,29 @@
 <td><code>boolean</code></td>
 <td><code>false</code></td>
 </tr>
+<tr>
+<td>componentOptions</td>
+<td>Options to pass along to the enforcer components</td>
+<td><code>object</code></td>
+<td>See <a href="/openapi-enforcer/api#component-options">Component Option</a></td>
+</tr>
+</tbody></table>
+<p><strong>Component Options</strong></p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Description</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>requestBodyAllowedMethods</td>
+<td>An <code>object</code> specifying which request methods to allow (or disallow) a request body for. The object you provide here will merge with the default value.</td>
+<td><code>object</code></td>
+<td><code>{ post: true, put: true, options: true, head: true, patch: true }</code></td>
+</tr>
 </tbody></table>
 <p><strong>Returns:</strong> A Promise</p>
 <ul>

--- a/examples/check-definition-for-errors.js
+++ b/examples/check-definition-for-errors.js
@@ -17,10 +17,10 @@
 'use strict';
 
 const Enforcer = require('../');
-const errors = Enforcer.errors({
+
+Enforcer({
     openapi: '3.0.0',
     info: {
         title: "My API"
     }
-});
-console.log(errors);
+}).then(null,errors => {console.log(errors)});

--- a/examples/request-response.js
+++ b/examples/request-response.js
@@ -94,8 +94,8 @@ const req = enforcer.request({
     path: '/shapes/square?color=red,blue'
 });
 
-const schema = req.operation.
+const schema = req.operation;
 const responseObject = req.operation.responses[200]
 .populate('application/json', {
-    headers:
-})
+    headers: ""
+});

--- a/index.js
+++ b/index.js
@@ -25,12 +25,15 @@ const Result                = require('./src/result');
 const Super                 = require('./src/super');
 const util                  = require('./src/util');
 
+const requestBodyAllowedMethods = { post: true, put: true, options: true, head: true, patch: true };
+
 /**
  * Create an Enforcer instance.
  * @param {string, object} definition
  * @param {object} [options]
  * @param {boolean} [options.hideWarnings=false] Set to true to hide warnings from the console.
  * @param {boolean} [options.fullResult=false] Set to true to get back a full result object with the value, warnings, and errors.
+ * @param {object} [options.internalOptions]
  * @returns {Promise<OpenApiEnforcer>}
  */
 async function Enforcer(definition, options) {
@@ -41,6 +44,11 @@ async function Enforcer(definition, options) {
     options = Object.assign({}, options);
     if (!options.hasOwnProperty('hideWarnings')) options.hideWarnings = false;
     if (!options.hasOwnProperty('fullResult')) options.fullResult = false;
+    if (!options.hasOwnProperty('internalOptions')) options.internalOptions = {};
+
+    if (!options.internalOptions.requestBodyAllowedMethods) {
+        options.internalOptions.requestBodyAllowedMethods = requestBodyAllowedMethods;
+    }
 
     const refParser = new RefParser();
     definition = util.copy(definition);
@@ -61,7 +69,7 @@ async function Enforcer(definition, options) {
             const validator = major === 2
                 ? Enforcer.v2_0.Swagger
                 : Enforcer.v3_0.OpenApi;
-            [ openapi, exception, warnings ] = validator(definition, refParser);
+            [ openapi, exception, warnings ] = validator(definition, refParser, options.internalOptions);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ async function Enforcer(definition, options) {
     let exception = Exception('One or more errors exist in the OpenAPI definition');
     const hasSwagger = definition.hasOwnProperty('swagger');
     if (!hasSwagger && !definition.hasOwnProperty('openapi')) {
-        exception('Missing required "openapi" or "swagger" property');
+        exception.message('Missing required "openapi" or "swagger" property');
 
     } else {
         const match = /^(\d+)(?:\.(\d+))(?:\.(\d+))?$/.exec(definition.swagger || definition.openapi);

--- a/index.js
+++ b/index.js
@@ -25,8 +25,6 @@ const Result                = require('./src/result');
 const Super                 = require('./src/super');
 const util                  = require('./src/util');
 
-const requestBodyAllowedMethods = { post: true, put: true, options: true, head: true, patch: true };
-
 /**
  * Create an Enforcer instance.
  * @param {string, object} definition
@@ -45,10 +43,6 @@ async function Enforcer(definition, options) {
     if (!options.hasOwnProperty('hideWarnings')) options.hideWarnings = false;
     if (!options.hasOwnProperty('fullResult')) options.fullResult = false;
     if (!options.hasOwnProperty('internalOptions')) options.internalOptions = {};
-
-    if (!options.internalOptions.requestBodyAllowedMethods) {
-        options.internalOptions.requestBodyAllowedMethods = requestBodyAllowedMethods;
-    }
 
     const refParser = new RefParser();
     definition = util.copy(definition);

--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ const util                  = require('./src/util');
  * @param {object} [options]
  * @param {boolean} [options.hideWarnings=false] Set to true to hide warnings from the console.
  * @param {boolean} [options.fullResult=false] Set to true to get back a full result object with the value, warnings, and errors.
- * @param {object} [options.internalOptions]
- * @returns {Promise<OpenApiEnforcer>}
+ * @param {object} [options.componentOptions] Options that get sent along to components.
+ * @returns {Promise<OpenApi|Swagger>|Promise<Result<OpenApi|Swagger>>}
  */
 async function Enforcer(definition, options) {
     let openapi;
@@ -42,7 +42,7 @@ async function Enforcer(definition, options) {
     options = Object.assign({}, options);
     if (!options.hasOwnProperty('hideWarnings')) options.hideWarnings = false;
     if (!options.hasOwnProperty('fullResult')) options.fullResult = false;
-    if (!options.hasOwnProperty('internalOptions')) options.internalOptions = {};
+    if (!options.hasOwnProperty('componentOptions')) options.componentOptions = {};
 
     const refParser = new RefParser();
     definition = util.copy(definition);
@@ -63,7 +63,7 @@ async function Enforcer(definition, options) {
             const validator = major === 2
                 ? Enforcer.v2_0.Swagger
                 : Enforcer.v3_0.OpenApi;
-            [ openapi, exception, warnings ] = validator(definition, refParser, options.internalOptions);
+            [ openapi, exception, warnings ] = validator(definition, refParser, options.componentOptions);
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Library for validating, parsing, and formatting data against open api schemas.",
   "main": "index.js",
   "directories": {

--- a/src/definition-validator.js
+++ b/src/definition-validator.js
@@ -46,6 +46,7 @@ function childData(parent, key, validator) {
         major: parent.major,
         map: parent.map,
         minor: parent.minor,
+        options: parent.options,
         parent,
         patch: parent.patch,
         plugins: parent.plugins,

--- a/src/enforcers/Operation.js
+++ b/src/enforcers/Operation.js
@@ -23,7 +23,6 @@ const Value         = require('../schema/value');
 
 const rxInteger = /^\d+$/;
 const rxNumber = /^\d+(?:\.\d+)?$/;
-const requestBodyAllowedMethods = { post: true, put: true, options: true, head: true, patch: true };
 
 module.exports = {
     init: function (data) {
@@ -420,7 +419,7 @@ module.exports = {
         }
     },
 
-    validator: function ({ major }) {
+    validator: function ({ major, options }) {
         return {
             type: 'object',
             properties: {
@@ -470,7 +469,7 @@ module.exports = {
                 },
                 requestBody: EnforcerRef('RequestBody', {
                     // for easy unit testing default key to post if there is no parent key
-                    allowed: ({ parent }) => major === 3 && !!requestBodyAllowedMethods[parent.key || 'post']
+                    allowed: ({ parent }) => major === 3 && !!options.requestBodyAllowedMethods[parent.key || 'post']
                 }),
                 responses: EnforcerRef('Responses', { required: true }),
                 schemes: {

--- a/src/enforcers/Operation.js
+++ b/src/enforcers/Operation.js
@@ -469,7 +469,7 @@ module.exports = {
                 },
                 requestBody: EnforcerRef('RequestBody', {
                     // for easy unit testing default key to post if there is no parent key
-                    allowed: ({ parent }) => major === 3 && !!options.requestBodyAllowedMethods[parent.key || 'post']
+                    allowed: ({ options, parent }) => major === 3 && !!options.requestBodyAllowedMethods[parent.key || 'post']
                 }),
                 responses: EnforcerRef('Responses', { required: true }),
                 schemes: {

--- a/src/super.js
+++ b/src/super.js
@@ -33,9 +33,9 @@ function createConstructor(version, name, enforcer) {
 
     // build the named constructor
     const F = new Function('build',
-        `const F = function ${name} (definition, refParser) {
-            if (!(this instanceof F)) return new F(definition, refParser)
-            return build(this, definition, refParser)
+        `const F = function ${name} (definition, refParser, options) {
+            if (!(this instanceof F)) return new F(definition, refParser, options)
+            return build(this, definition, refParser, options)
         }
         return F`
     )(build);
@@ -91,7 +91,7 @@ function createConstructor(version, name, enforcer) {
         });
     }
 
-    function build (result, definition, refParser) {
+    function build (result, definition, refParser, options) {
         const isStart = !definitionValidator.isValidatorState(definition);
 
         // validate the definition
@@ -117,6 +117,7 @@ function createConstructor(version, name, enforcer) {
                 staticData,
                 validator: enforcer.validator,
                 warn: Exception('One or more warnings exist in the ' + name + ' definition'),
+                options: options
             };
             data.root = data;
 

--- a/src/super.js
+++ b/src/super.js
@@ -98,9 +98,9 @@ function createConstructor(version, name, enforcer) {
 
         // normalize options
         if (!options) options = {};
-        if (!options.requestBodyAllowedMethods) {
-            options.requestBodyAllowedMethods = requestBodyAllowedMethods;
-        }
+        options.requestBodyAllowedMethods = options.hasOwnProperty('requestBodyAllowedMethods')
+            ? Object.assign({}, requestBodyAllowedMethods, options.requestBodyAllowedMethods)
+            : requestBodyAllowedMethods;
 
         // validate the definition
         let data;

--- a/src/super.js
+++ b/src/super.js
@@ -22,6 +22,8 @@ const Exception             = require('./exception');
 const Result                = require('./result');
 const util                  = require('./util');
 
+const requestBodyAllowedMethods = { post: true, put: true, options: true, head: true, patch: true };
+
 function Super (version, name, enforcer) {
     if (!enforcer) enforcer = require('./enforcers/' + name);
     return createConstructor(version, name, enforcer);
@@ -93,6 +95,12 @@ function createConstructor(version, name, enforcer) {
 
     function build (result, definition, refParser, options) {
         const isStart = !definitionValidator.isValidatorState(definition);
+
+        // normalize options
+        if (!options) options = {};
+        if (!options.requestBodyAllowedMethods) {
+            options.requestBodyAllowedMethods = requestBodyAllowedMethods;
+        }
 
         // validate the definition
         let data;

--- a/test/enforcer.request-body.test.js
+++ b/test/enforcer.request-body.test.js
@@ -52,6 +52,56 @@ describe('enforcer/request-body', () => {
         expect(err).to.match(/Property not allowed: requestBody/);
     });
 
+    it('can overwrite options to allow for GET method', () => {
+        const [ , err ] = Enforcer.v3_0.PathItem({
+            get: {
+                requestBody: {
+                    content: {
+                        'application/json': {
+
+                        }
+                    }
+                },
+                responses: {
+                    default: {
+                        description: ''
+                    }
+                }
+            }
+        }, null, { requestBodyAllowedMethods: { get: true } });
+        expect(err).to.equal(undefined)
+    });
+
+    it('can overwrite options to allow for GET method through root instantiation', async () => {
+        const defintion = {
+            openapi: '3.0.0',
+            info: { title: '', version: '' },
+            paths: {
+                '/': {
+                    get: {
+                        requestBody: {
+                            content: {
+                                'application/json': {}
+                            }
+                        },
+                        responses: {
+                            default: {
+                                description: ''
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const [ , err ] = await Enforcer(defintion, {
+            fullResult: true,
+            componentOptions: {
+                requestBodyAllowedMethods: { get: true }
+            }
+        });
+        expect(err).to.equal(undefined)
+    });
+
     describe('encoding', () => {
 
         it('is allowed with multipart mimetype', () => {


### PR DESCRIPTION
Add flexibility to the enforcer components to allow options to be passed into them. At the moment only one option (requestBodyAllowedMethods) can be passed in.