### PR TITLE
Decode uri component path parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ async function Enforcer(definition, options) {
     } else {
         const match = /^(\d+)(?:\.(\d+))(?:\.(\d+))?$/.exec(definition.swagger || definition.openapi);
         if (!match) {
-            exception.at(hasSwagger ? 'swagger' : 'openapi')('Invalid value');
+            exception.at(hasSwagger ? 'swagger' : 'openapi').message('Invalid value');
 
         } else {
             const major = +match[1];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Library for validating, parsing, and formatting data against open api schemas.",
   "main": "index.js",
   "directories": {

--- a/src/enforcers/Paths.js
+++ b/src/enforcers/Paths.js
@@ -104,7 +104,7 @@ module.exports = {
 
                     // get path parameter strings
                     const pathParams = {};
-                    parameterNames.forEach((name, index) => pathParams[name] = match[index + 1]);
+                    parameterNames.forEach((name, index) => pathParams[name] = decodeURIComponent(match[index + 1]));
 
                     return {
                         params: pathParams,


### PR DESCRIPTION
Path parameters with URI encoding were not decoded previously, causing invalid validation errors on string length checks.