### PR TITLE
Fixing discriminate call on "oneOf"

### DIFF
--- a/src/schema/validate.js
+++ b/src/schema/validate.js
@@ -75,7 +75,7 @@ function runValidate(exception, map, schema, originalValue, options) {
 
     } else if (schema.oneOf) {
         if (schema.discriminator) {
-            const data = schema.getDiscriminator(value);
+            const data = schema.discriminate(value, true);
             const subSchema = data.schema;
             const key = data.key;
             if (!subSchema) {


### PR DESCRIPTION
While I was trying the openapi-enforcer in one of all projects, I found this small bug on the discrimination for "oneOf ".