### PR TITLE
Fix components callbacks validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Library for validating, parsing, and formatting data against open api schemas.",
   "main": "index.js",
   "directories": {

--- a/src/enforcers/Components.js
+++ b/src/enforcers/Components.js
@@ -29,7 +29,10 @@ module.exports = {
             allowed: major === 3,
             type: 'object',
             properties: {
-                callbacks: EnforcerRef('Callback'),
+                callbacks: {
+                    type: 'object',
+                    additionalProperties: EnforcerRef('Callback')
+                },
                 examples: {
                     type: 'object',
                     additionalProperties: EnforcerRef('Example')

--- a/src/enforcers/OpenApi.js
+++ b/src/enforcers/OpenApi.js
@@ -130,49 +130,7 @@ module.exports = {
                         if (definition[0] !== '/') exception.message('Value must start with a forward slash');
                     }
                 },
-                components: {
-                    weight: -1,
-                    allowed: major === 3,
-                    type: 'object',
-                    properties: {
-                        callbacks: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('Callback')
-                        },
-                        examples: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('Example')
-                        },
-                        headers: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('Header')
-                        },
-                        links: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('Link')
-                        },
-                        parameters: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('Parameter')
-                        },
-                        requestBodies: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('RequestBody')
-                        },
-                        responses: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('Response')
-                        },
-                        schemas: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('Schema')
-                        },
-                        securitySchemes: {
-                            type: 'object',
-                            additionalProperties: EnforcerRef('SecurityScheme')
-                        },
-                    }
-                },
+                components: EnforcerRef('Components', { weight: -1, allowed: major === 3 }),
                 consumes: {
                     allowed: major === 2,
                     type: 'array',

--- a/src/enforcers/OpenApi.js
+++ b/src/enforcers/OpenApi.js
@@ -135,7 +135,10 @@ module.exports = {
                     allowed: major === 3,
                     type: 'object',
                     properties: {
-                        callbacks: EnforcerRef('Callback'),
+                        callbacks: {
+                            type: 'object',
+                            additionalProperties: EnforcerRef('Callback')
+                        },
                         examples: {
                             type: 'object',
                             additionalProperties: EnforcerRef('Example')

--- a/test/definition.callback.test.js
+++ b/test/definition.callback.test.js
@@ -1,0 +1,82 @@
+/**
+ *  @license
+ *    Copyright 2019 Brigham Young University
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ **/
+'use strict';
+const Enforcer      = require('../index');
+const expect        = require('chai').expect;
+
+describe('definition/callback', () => {
+    const callbackDef = {
+        '{$request.body#/successUrl}': {
+            post: {
+                requestBody: {
+                    content: {
+                        'text/plain': {
+                            schema: { type: 'string' }
+                        }
+                    }
+                },
+                responses: {
+                    '200': { description: 'OK' }
+                }
+            }
+        }
+    };
+
+    const pathDef = {
+        post: {
+            requestBody: {
+                content: {
+                    'application/json': {
+                        schema: {
+                            type: 'object',
+                            properties: {
+                                successUrl: { type: 'string' }
+                            }
+                        }
+                    }
+                }
+            },
+            responses: {
+                '200': { description: 'OK' }
+            },
+            callbacks: {
+                inProgress: callbackDef
+            }
+        }
+    };
+
+    it('can exist within a path item', () => {
+        const [ pathItem, err ] = new Enforcer.v3_0.PathItem(pathDef);
+        expect(err).to.equal(undefined);
+        expect(pathItem.post.callbacks.inProgress).to.be.instanceof(Enforcer.v3_0.Callback);
+    });
+
+    it('can be exist within the components section', () => {
+        const [ , err ] = new Enforcer.v3_0.OpenApi({
+            openapi: '3.0.0',
+            info: { title: '', version: '' },
+            paths: {},
+            components: {
+                callbacks: {
+                    myCallback: callbackDef
+                }
+            }
+        });
+        expect(err).to.equal(undefined);
+    })
+
+});

--- a/test/definition.open-api.test.js
+++ b/test/definition.open-api.test.js
@@ -82,10 +82,12 @@ describe('definitions/open-api', () => {
                     components: {
                         callbacks: {
                             abc: {
-                                get: {
-                                    responses: {
-                                        200: {
-                                            description: 'ok'
+                                '{$request.body#/something}': {
+                                    get: {
+                                        responses: {
+                                            200: {
+                                                description: 'ok'
+                                            }
                                         }
                                     }
                                 }
@@ -101,7 +103,9 @@ describe('definitions/open-api', () => {
                     components: {
                         callbacks: {
                             abc: {
-                                get: {}
+                                '{$request.body#/something}': {
+                                    get: {}
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
For Open API spec 3.x.x there was an error in the validator definition for OpenAPI > Components > Callbacks.

This PR fixes the validator, updates tests to be correct, and adds a few tests. Also, I noticed that the top level OpenAPI enforcer was not using the defined Components enforcer (it was using a copy of the Components enforcer's code) so I fixed that too.