### PR TITLE
Mime type warning fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Library for validating, parsing, and formatting data against open api schemas.",
   "main": "index.js",
   "directories": {

--- a/src/enforcers/MediaType.js
+++ b/src/enforcers/MediaType.js
@@ -49,11 +49,16 @@ module.exports = {
                     additionalProperties: EnforcerRef('Example')
                 },
                 schema: EnforcerRef('Schema')
+            },
+            errors: ({ parent, key, warn }) => {
+                if (parent && parent.key === 'content') {
+                    if (!module.exports.rx.mediaType.test(key)) warn.message('Media type appears invalid');
+                }
             }
         }
     },
 
     rx: {
-        mediaType: /^(application|audio|example|font|image|message|model|multipart|text|video)\/(?:([a-z.\-]+)\+)?([a-z.\-]+)(?:; (.+))?$/
+        mediaType: /^(application|audio|example|font|image|message|model|multipart|text|video|x-\S+)\/(?:([a-z.\-]+)\+)?([a-z.\-]+)(?:; *(.+))?$/
     }
 };

--- a/src/enforcers/Response.js
+++ b/src/enforcers/Response.js
@@ -30,7 +30,6 @@ module.exports = {
     prototype: {},
 
     validator: function ({ major }) {
-        const MediaType = require('./MediaType');
         return {
             type: 'object',
             properties: {
@@ -41,11 +40,7 @@ module.exports = {
                 content: {
                     allowed: major === 3,
                     type: 'object',
-                    additionalProperties: EnforcerRef('MediaType', {
-                        errors: function({ key, warn }) {
-                            if (!MediaType.rx.mediaType.test(key)) warn.message('Media type appears invalid');
-                        }
-                    })
+                    additionalProperties: EnforcerRef('MediaType')
                 },
                 examples: {
                     allowed: major === 2,


### PR DESCRIPTION
Improve the regular expression that is run to check mime types and provide warnings so that it allows the x-token type as well as not requiring a space before mime type parameters.