### PR TITLE
Add support for fractional value of multipleOf, when schema type=number

### DIFF
--- a/src/schema/validate.js
+++ b/src/schema/validate.js
@@ -210,7 +210,7 @@ function runValidate(exception, map, schema, originalValue, options) {
                 if (options.maxMin !== false) {
                     maxMin(exception, schema, 'number', 'maximum', 'minimum', true, value, schema.maximum, schema.minimum);
                 }
-                if (schema.multipleOf && value % schema.multipleOf !== 0) {
+                if (schema.multipleOf && !Number.isInteger(value / schema.multipleOf)) {
                     exception.message('Expected a multiple of ' + schema.multipleOf + '. Received: ' + util.smart(value));
                 }
             }


### PR DESCRIPTION
Consider following schema example, which is valid with OpenAPI 3.0 and describes the precision of number:

```
type: number
multipleOf: 0.01
example: 7.28
```

After applying proposed change, you will not get warning message from src/schema/validate.js:214.