### PR TITLE
oneOf not always object

### DIFF
--- a/test/definition.schema.test.js
+++ b/test/definition.schema.test.js
@@ -2165,6 +2165,36 @@ describe('definition/schema', () => {
 
         });
 
+        it('oneOf any type', async () => {
+            const definition = {
+                type: 'object',
+                "properties": {
+                    "value": {
+                        "oneOf": [
+                            { "type": "string" },
+                            { "type": "number" },
+                            { "type": "boolean" },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "oneOf": [
+                                        { "type": "string" },
+                                        { "type": "number" },
+                                        { "type": "boolean" },
+                                        { "type": "object" }
+                                    ]
+                                }
+                            },
+                            { "type": "object" }
+                        ]
+                    }
+                }
+            };
+            const [ schema ] = Enforcer.v3_0.Schema(definition);
+            const deserialized = schema.deserialize('hello');
+            expect(deserialized.value).to.equal('hello')
+        });
+
     });
 
     describe('discriminate', () => {

--- a/test/definition.schema.test.js
+++ b/test/definition.schema.test.js
@@ -2165,34 +2165,60 @@ describe('definition/schema', () => {
 
         });
 
-        it('oneOf any type', async () => {
-            const definition = {
-                type: 'object',
-                "properties": {
-                    "value": {
-                        "oneOf": [
-                            { "type": "string" },
-                            { "type": "number" },
-                            { "type": "boolean" },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        { "type": "string" },
-                                        { "type": "number" },
-                                        { "type": "boolean" },
-                                        { "type": "object" }
-                                    ]
-                                }
-                            },
-                            { "type": "object" }
-                        ]
-                    }
-                }
+        describe('allOf', () => {
+
+            it('number', () => {
+                const [ schema, err ] = Enforcer.v3_0.Schema({
+                    allOf: [
+                        { type: 'number' },
+                        { type: 'number', minimum: 0 }
+                    ]
+                });
+                const deserialized = schema.deserialize(1);
+                expect(deserialized.value).to.equal(1)
+            })
+
+        });
+
+        describe('oneOf', () => {
+            const anyTypeDef = {
+                "oneOf": [
+                    { "type": "string" },
+                    { "type": "number" },
+                    { "type": "boolean" },
+                    {
+                        "type": "array",
+                        "items": {
+                            "oneOf": [
+                                { "type": "string" },
+                                { "type": "number" },
+                                { "type": "boolean" },
+                                { "type": "object" }
+                            ]
+                        }
+                    },
+                    { "type": "object" }
+                ]
             };
-            const [ schema ] = Enforcer.v3_0.Schema(definition);
-            const deserialized = schema.deserialize('hello');
-            expect(deserialized.value).to.equal('hello')
+
+            it('oneOf any type as string', async () => {
+                const [ schema ] = Enforcer.v3_0.Schema(anyTypeDef);
+                const deserialized = schema.deserialize('hello');
+                expect(deserialized.value).to.equal('hello')
+            });
+
+            it('oneOf any type as number', async () => {
+                const [ schema ] = Enforcer.v3_0.Schema(anyTypeDef);
+                const deserialized = schema.deserialize(1);
+                expect(deserialized.value).to.equal(1)
+            });
+
+            it('oneOf any type as boolean', async () => {
+                const [ schema ] = Enforcer.v3_0.Schema(anyTypeDef);
+                const deserialized = schema.deserialize(true);
+                expect(deserialized.value).to.equal(true)
+            });
+
         });
 
     });
@@ -3391,6 +3417,22 @@ describe('definition/schema', () => {
                 schema.anyOf[0].properties.birthDate.format = 'date';
                 const [ , err ] = schema.deserialize({ packSize: 5, birthDate: '2000-01-01' });
                 expect(err).to.equal(undefined);
+            });
+
+        });
+
+        describe('oneOf', () => {
+
+            it('can serialize number or boolean', () => {
+                const [schema, err] = Enforcer.v3_0.Schema({
+                    oneOf: [
+                        { type: 'number' },
+                        { type: 'boolean' }
+                    ]
+                });
+                console.log(err);
+                const [value] = schema.serialize(1);
+                expect(value).to.equal(1);
             });
 
         });


### PR DESCRIPTION
Deserialize is using Object.assign for deserializing objects but it needed a check for deserializing non-objects.