### PR TITLE
Maximum call stack size exceeded cased by allOf and circular references

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -36,3 +36,16 @@ exports.willReject = async function(callback, error) {
             }
         )
 };
+
+exports.wontReject = function(callback, error) {
+    return callback()
+        .catch(
+            err => {
+                if (!error) {
+                    throw new Error('Expected no rejection')
+                } else {
+                    expect(err.toString()).to.not.match(error)
+                }
+            }
+        )
+};

--- a/src/enforcers/Schema.js
+++ b/src/enforcers/Schema.js
@@ -1109,18 +1109,25 @@ function numericType (schema) {
     }
 }
 
-function serializeSchema (schema, exception, dataTypes) {
+function serializeSchema (schema, exception, dataTypes, serializedSchemas) {
+    if (!serializedSchemas) {
+        serializedSchemas = [schema];
+    } else if (!serializedSchemas.includes(schema)) {
+        serializedSchemas.push(schema);
+    } else {
+        return schema;
+    }
     if (schema.type === 'array' && schema.items) {
-        schema.items = serializeSchema(schema.items, exception.at('items'), dataTypes);
+        schema.items = serializeSchema(schema.items, exception.at('items'), dataTypes, serializedSchemas);
     } else if (schema.type === 'object') {
         if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
-            schema.additionalProperties = serializeSchema(schema.additionalProperties, exception.at('additionalProperties'), dataTypes)
+            schema.additionalProperties = serializeSchema(schema.additionalProperties, exception.at('additionalProperties'), dataTypes, serializedSchemas)
         }
         if (schema.properties) {
             const childException = exception.at('properties');
             Object.keys(schema.properties)
                 .forEach(key => {
-                    schema.properties[key] = serializeSchema(schema.properties[key], childException.at(key), dataTypes)
+                    schema.properties[key] = serializeSchema(schema.properties[key], childException.at(key), dataTypes, serializedSchemas)
                 });
         }
     } else {

--- a/test/definition.schema.test.js
+++ b/test/definition.schema.test.js
@@ -104,6 +104,44 @@ describe('definition/schema', () => {
             }
         }
     };
+    const allOfCircular = {
+        openapi: '3.0.0',
+        info: {title: '', version: ''},
+        paths: {
+            '/MatryoshkaSouvenir': {
+                get: {
+                    responses: {
+                        200: {
+                            description: 'Returns MatryoshkaSouvenir',
+                            content: {
+                                'application/json': {
+                                    schema: {$ref: '#/components/schemas/MatryoshkaSouvenir'}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        components: {
+            schemas: {
+                GiftCard: {
+                    properties: {text: {type: 'string'}},
+                    type: 'object'
+                },
+                Matryoshka: {
+                    properties: {matryoshka: {'$ref': '#/components/schemas/Matryoshka'}},
+                    type: 'object'
+                },
+                MatryoshkaSouvenir: {
+                    allOf: [
+                        {'$ref': '#/components/schemas/GiftCard'},
+                        {'$ref': '#/components/schemas/Matryoshka'}
+                    ]
+                }
+            }
+        }
+    };
     const anyOfDef = {
         openapi: '3.0.0',
         info: { title: '', version: '' },
@@ -326,6 +364,10 @@ describe('definition/schema', () => {
                     ]
                 });
                 expect(err).to.equal(undefined);
+            });
+
+            it('allows circular references at schemas', async () => {
+                await assert.wontReject(() => Enforcer(util.copy(allOfCircular)), /Maximum call stack size exceeded/);
             });
 
             describe('merges', () => {


### PR DESCRIPTION
When `allOf` combined with circular referenced schemas enforcer fails with `Maximum call stack size exceeded` error.

```yaml
openapi: 3.0.0
info:
  title: ""
  version: ""
paths:
  "/MatryoshkaSouvenir":
    get:
      responses:
        '200':
          description: Returns MatryoshkaSouvenir
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/MatryoshkaSouvenir"
components:
  schemas:
    GiftCard:
      properties:
        text:
          type: string
      type: object
    Matryoshka:
      properties:
        matryoshka:
          $ref: "#/components/schemas/Matryoshka"
      type: object
    MatryoshkaSouvenir:
      allOf:
      - $ref: "#/components/schemas/GiftCard"
      - $ref: "#/components/schemas/Matryoshka"
```

Error caused by [serializeSchema](https://github.com/byu-oit/openapi-enforcer/blob/0d3093bb1115a31d5a218b4657211ec1c14adfc1/src/enforcers/Schema.js#L1112), it doesn't prevent single schema to processed more than once.

There maybe other issues like this and #39, which related with circular references.