### PR TITLE
Should allow whitespaces in base64 string

### DIFF
--- a/src/data-type-formats.js
+++ b/src/data-type-formats.js
@@ -76,10 +76,15 @@ exports.byte = {
     deserialize: function ({ exception, value }) {
         if (value instanceof Buffer) {
             return value;
-        } else if (typeof value !== 'string' || !rx.byte.test(value) || value.length % 4 !== 0) {
-            exception.message('Expected a base64 string');
+        } else if (typeof value === 'string') {
+            value = value.replace(/(\s)/gm, "");
+            if (!rx.byte.test(value) || value.length % 4 !== 0) {
+                exception.message('Expected a base64 string');
+            } else {
+                return Buffer.from ? Buffer.from(value, 'base64') : new Buffer(value, 'base64');
+            }
         } else {
-            return Buffer.from ? Buffer.from(value, 'base64') : new Buffer(value, 'base64');
+            exception.message('Expected a base64 string');
         }
     },
 

--- a/test/definition.schema.test.js
+++ b/test/definition.schema.test.js
@@ -1929,6 +1929,16 @@ describe('definition/schema', () => {
                 expect(err).to.match(/Expected a base64 string/);
             });
 
+            it('does allow line returns', () => {
+                const [value] = schema.deserialize("TQ\n==\n");
+                expect(value).to.be.an.instanceof(Buffer);
+            });
+
+            it('does allow spaces and tabs', () => {
+                const [value] = schema.deserialize("\tTQ \t==");
+                expect(value).to.be.an.instanceof(Buffer);
+            });
+
         });
 
         describe('date', () => {


### PR DESCRIPTION
Fix for https://github.com/byu-oit/openapi-enforcer/issues/49