### PR TITLE
Decode uri params

### DIFF
--- a/src/enforcers/Operation.js
+++ b/src/enforcers/Operation.js
@@ -131,7 +131,7 @@ module.exports = {
             const req = {
                 header: util.lowerCaseObjectProperties(request.headers),
                 path: request.path,
-                query: util.parseQueryString(request.query)
+                query: util.parseQueryString(decodeURI(request.query))
             };
             if (request.body !== undefined) req.body = request.body;
             const cookie = req.header.cookie || '';

--- a/src/enforcers/Parameter.js
+++ b/src/enforcers/Parameter.js
@@ -71,6 +71,10 @@ module.exports = {
 
             const exception = Exception('Unable to parse value');
 
+            if (this.in === 'path' || this.in === 'query') {
+                value = decodeURIComponent(value);
+            }
+
             if (major === 2) {
                 if (this.collectionFormat === 'multi') {
                     if (!query) query = util.parseQueryString(value);

--- a/src/enforcers/Paths.js
+++ b/src/enforcers/Paths.js
@@ -115,7 +115,7 @@ module.exports = {
 
                     // get path parameter strings
                     const pathParams = {};
-                    parameterNames.forEach((name, index) => pathParams[name] = decodeURIComponent(match[index + 1]));
+                    parameterNames.forEach((name, index) => pathParams[name] = match[index + 1]);
 
                     return {
                         params: pathParams,

--- a/src/result.js
+++ b/src/result.js
@@ -23,8 +23,8 @@ module.exports = EnforcerResult;
 /**
  * Produce an EnforcerResult
  * @param {*} value
- * @param {Exception} [exception]
- * @param {Exception} [warn]
+ * @param {EnforcerException} [exception]
+ * @param {EnforcerException} [warn]
  * @constructor
  */
 function EnforcerResult(value, exception, warn) {


### PR DESCRIPTION
This code has a fix to better handle URI decoding for path and query parameters. It also makes sure that other parameter types do not run through URI decoding.