### PR TITLE
Added propagation of pathKey to request result

### DIFF
--- a/src/enforcers/OpenApi.js
+++ b/src/enforcers/OpenApi.js
@@ -83,7 +83,8 @@ module.exports = {
             if (exception.hasException) return new Result(undefined, exception);
             return new Result({
                 operation,
-                params
+                params,
+                pathKey: pathMatch.pathKey
             });
         },
 
@@ -122,7 +123,7 @@ module.exports = {
             if (error) return new Result(undefined, error);
 
             // set up request input
-            const { operation, params } = pathObject;
+            const { operation, params, pathKey } = pathObject;
             const req = {
                 headers: request.headers || {},
                 path: params,
@@ -141,6 +142,7 @@ module.exports = {
                     }
                     return operation.response(code, body, headers)
                 }
+                result.value.pathKey = pathKey;
             }
             return result;
         }

--- a/src/enforcers/Paths.js
+++ b/src/enforcers/Paths.js
@@ -119,7 +119,8 @@ module.exports = {
 
                     return {
                         params: pathParams,
-                        path
+                        path,
+                        pathKey
                     };
                 };
 


### PR DESCRIPTION
I have a case where I specify handlers for request via the path specified in the OpenApi 3 spec file. So when I get a request and have validated that with the enforcers request method I would like to also get which path the enforcer matched it against.

This pull request will give give that pathKey so I can do this match.
