### PR TITLE
#79 Change from Buffer constructors to Buffer.from()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,5 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# VS Code 
+.history

--- a/src/data-type-formats.js
+++ b/src/data-type-formats.js
@@ -32,7 +32,7 @@ exports.binary = {
             const length = value.length;
             const array = [];
             for (let i = 0; i < length; i += 8) array.push(parseInt(value.substr(i, 8), 2))
-            return Buffer.from ? Buffer.from(array, 'binary') : new Buffer(array, 'binary');
+            return Buffer.from(array, 'binary');
         }
     },
 
@@ -81,7 +81,7 @@ exports.byte = {
             if (!rx.byte.test(value) || value.length % 4 !== 0) {
                 exception.message('Expected a base64 string');
             } else {
-                return Buffer.from ? Buffer.from(value, 'base64') : new Buffer(value, 'base64');
+                return Buffer.from(value, 'base64');
             }
         } else {
             exception.message('Expected a base64 string');


### PR DESCRIPTION
A fix to the issue described in [issue #79](https://github.com/byu-oit/openapi-enforcer/issues/79)