### PR TITLE
Same paths with different HTTP verbs should be valid

### DIFF
--- a/src/enforcers/Paths.js
+++ b/src/enforcers/Paths.js
@@ -93,18 +93,23 @@ module.exports = {
                     rxStr += escapeRegExp(subStr);
                     paramlessStr += subStr;
                 }
+
+                path.methods.forEach(method => {
+                    equivalencyKey += method + equivalencyKey;
+
+                    if (!paramlessMap[equivalencyKey]) paramlessMap[equivalencyKey] = [];
+                    const paramless = paramlessMap[equivalencyKey];
+
+                    if (!pathEquivalencies[equivalencyKey]) pathEquivalencies[equivalencyKey] = [];
+                    if (pathEquivalencies[equivalencyKey].length === 0) pathEquivalencies[equivalencyKey].push(pathKey);
+                    if (!paramless.includes(paramlessStr)) {
+                        paramless.push(paramlessStr);
+                    } else {
+                        pathEquivalencies[equivalencyKey].push(pathKey);
+                    }
+                });
+
                 const rx = new RegExp('^' + rxStr + '$');
-
-                if (!paramlessMap[equivalencyKey]) paramlessMap[equivalencyKey] = [];
-                const paramless = paramlessMap[equivalencyKey];
-
-                if (!pathEquivalencies[equivalencyKey]) pathEquivalencies[equivalencyKey] = [];
-                if (pathEquivalencies[equivalencyKey].length === 0) pathEquivalencies[equivalencyKey].push(pathKey);
-                if (!paramless.includes(paramlessStr)) {
-                    paramless.push(paramlessStr);
-                } else {
-                    pathEquivalencies[equivalencyKey].push(pathKey);
-                }
 
                 // define parser function
                 const parser = pathString => {

--- a/test/enforcer.paths.test.js
+++ b/test/enforcer.paths.test.js
@@ -20,9 +20,9 @@ const Enforcer      = require('../');
 
 describe('enforcer/paths', () => {
 
-    function validPathObject (parameters) {
+    function validPathObject (parameters, verb = 'get') {
         const result = {
-            get: {
+            [verb]: {
                 responses: {
                     default: {
                         description: ''
@@ -99,6 +99,19 @@ describe('enforcer/paths', () => {
         });
         expect(err).to.match(/Equivalent paths are not allowed/);
         expect(err.count).to.equal(5);
+    });
+
+    it('allows duplicate paths, if verbs differ', () => {
+        const [ , err, warning ] = Enforcer.v2_0.Paths({
+            '/a/{e}': validPathObject([
+                { name: 'e', in: 'path', required: true, type: 'string' }
+            ]),
+            '/a/{y}': validPathObject([
+                { name: 'y', in: 'path', required: true, type: 'string' }
+            ], 'put')
+        });
+        expect(err).to.equal(undefined);
+        expect(warning).to.equal(undefined);
     });
 
     it('correctly prioritizes path selection', () => {


### PR DESCRIPTION
Same paths with different HTTP verbs should not be considered equivalent.

Same paths means: same segments, only path variable names can be different.

E.g.

```
GET /a/{e}
PUT /a/{y}
```

should be valid.