### PR TITLE
Schema type optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.12.0
+
+### Changed
+
+- **Schema type not required**
+
+    Previous versions have required the `type` property to be specified for schemas (except in the case where one of `allOf`, `anyOf`, `oneOf`, and `not` are defined).
+    
+    This update no longer requires `type` to be specified. If `type` is not specified then the OpenAPI Enforcer will attempt to auto determine type. If the type cannot be determined and should exist then warning `WSCH005` ("Schemas with an indeterminable type cannot serialize, deserialize, or validate values.") will be generated.
+
 ## 1.11.2
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-enforcer",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "description": "Library for validating, parsing, and formatting data against open api schemas.",
   "main": "index.js",
   "directories": {

--- a/src/definition-validator.js
+++ b/src/definition-validator.js
@@ -176,10 +176,13 @@ function normalize (data) {
 
                         // set default value
                         if (data.definition === undefined && allowed && keyValidator.hasOwnProperty('default')) {
-                            data.definition = fn(keyValidator.default, data);
-                            data.usedDefault = true;
-                            data.parent.definition[key] = data.definition;
-                            data.definitionType = util.getDefinitionType(data.definition);
+                            const defaultValue = fn(keyValidator.default, data);
+                            if (defaultValue !== undefined) {
+                                data.definition = defaultValue
+                                data.usedDefault = true;
+                                data.parent.definition[key] = data.definition;
+                                data.definitionType = util.getDefinitionType(data.definition);
+                            }
                         }
 
                         if (data.definition !== undefined) {

--- a/src/enforcers/Schema.js
+++ b/src/enforcers/Schema.js
@@ -682,13 +682,12 @@ module.exports = {
                 type: {
                     weight: -10,
                     type: 'string',
-                    // required: ({ parent }) => {
-                    //     const v = parent.definition;
-                    //     return !v.hasOwnProperty('allOf') && !v.hasOwnProperty('anyOf') &&
-                    //         !v.hasOwnProperty('not') && !v.hasOwnProperty('oneOf');
-                    // },
                     default: ({ parent }) => {
                         const def = parent.definition
+
+                        // if schema has allOf, anyOf, not, or oneOf then dont set a type
+                        if (def.hasOwnProperty('allOf') || def.hasOwnProperty('anyOf') ||
+                            def.hasOwnProperty('not') || def.hasOwnProperty('oneOf')) return
 
                         // attempt to use sibling properties to determine type
                         for (let i = typeProperties.length; i--; i >= 0) {

--- a/src/schema/deserialize.js
+++ b/src/schema/deserialize.js
@@ -108,7 +108,7 @@ function runDeserialize(exception, map, schema, originalValue, options) {
 
     } else if (schema !== true) {
         const dataTypes = schema.enforcerData.staticData.dataTypes;
-        const dataType = dataTypes[schema.type][schema.format] || null;
+        const dataType = (dataTypes[schema.type] && dataTypes[schema.type][schema.format]) || null;
 
         if (type === 'boolean') {
             if (dataType && dataType.deserialize) {

--- a/src/schema/random.js
+++ b/src/schema/random.js
@@ -139,7 +139,7 @@ function runRandom(exception, warn, map, schema, parent, property, options, dept
 
     } else if (!parent.hasOwnProperty(property) || depth === 0) {
         const dataTypes = schema.enforcerData.staticData.dataTypes;
-        const dataType = dataTypes[schema.type][schema.format] || null;
+        const dataType = (dataTypes[schema.type] && dataTypes[schema.type][schema.format]) || null;
 
         if (dataType && dataType.random) {
             parent[property] = dataType.random({ exception, schema }, { chooseOne, randomNumber, randomText });

--- a/src/schema/serialize.js
+++ b/src/schema/serialize.js
@@ -96,7 +96,7 @@ function runSerialize(exception, map, schema, originalValue) {
 
     } else if (schema !== true) {
         const dataTypes = schema.enforcerData.staticData.dataTypes;
-        const dataType = dataTypes[schema.type][schema.format] || {};
+        const dataType = (dataTypes[schema.type] && dataTypes[schema.type][schema.format]) || {};
         if (!dataType.serialize) dataType.serialize = function({ value }) { return value };
 
         if (type === 'boolean') {

--- a/src/schema/validate.js
+++ b/src/schema/validate.js
@@ -183,7 +183,7 @@ function runValidate(exception, map, schema, originalValue, options) {
 
     } else {
         const dataTypes = schema.enforcerData.staticData.dataTypes;
-        const dataType = dataTypes[schema.type][schema.format] || { validate: null };
+        const dataType = (dataTypes[schema.type] && dataTypes[schema.type][schema.format]) || { validate: null };
 
         if (dataType.validate) {
             dataType.validate({ exception, schema, value });

--- a/test/definition-validator.test.js
+++ b/test/definition-validator.test.js
@@ -674,10 +674,9 @@ describe('definition-validator', () => {
             }
         };
         const [ , err ] = await Enforcer(def, { fullResult: true });
-        expect(err.count).to.equal(3);
+        expect(err.count).to.equal(2);
         expect(err).to.match(/Property not allowed: foo/);
         expect(err).to.match(/Properties not allowed:/);
-        expect(err).to.match(/Missing required property: type/);
     })
 
 });

--- a/test/definition.open-api.test.js
+++ b/test/definition.open-api.test.js
@@ -310,17 +310,6 @@ describe('definitions/open-api', () => {
                 expect(err).to.be.undefined;
             });
 
-            it('must be an object of schemas', () => {
-                const [ , err ] = oas(3, {
-                    components: {
-                        schemas: {
-                            schemaA: {}
-                        }
-                    }
-                });
-                expect(err).to.match(/Missing required property: type/);
-            });
-
         });
 
         describe('securitySchemes', () => {
@@ -408,15 +397,6 @@ describe('definitions/open-api', () => {
                 definitions: []
             });
             expect(err).to.match(/Value must be a plain object/);
-        });
-
-        it('must have valid schemas per key', () => {
-            const [ , err ] = oas(2, {
-                definitions: {
-                    def1: {}
-                }
-            });
-            expect(err).to.match(/Missing required property: type/);
         });
 
     });

--- a/test/definition.schema.test.js
+++ b/test/definition.schema.test.js
@@ -198,11 +198,38 @@ describe('definition/schema', () => {
             expect(err).to.be.undefined;
         });
 
-        describe('type', () => {
+        describe.only('type', () => {
 
-            it('requires the "type" property', () => {
-                const [ , err ] = Enforcer.v2_0.Schema({});
-                expect(err).to.match(/Missing required property: type/);
+            it('will warn of the missing "type" property', () => {
+                const [ v, err, warn ] = Enforcer.v2_0.Schema({});
+                expect(err).to.be.undefined;
+                expect(warn).to.match(/Schemas with an indeterminable type/);
+            });
+
+            it('will allow escalation of the missing "type" property', async () => {
+                const def = {
+                    openapi: '3.0.0',
+                    info: { title: '', version: '' },
+                    paths: {
+                        '/': {
+                            get: {
+                                responses: {
+                                    '200': {
+                                        description: 'OK',
+                                        content: {
+                                            'application/json': {
+                                                schema: {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                const [ openapi, err, warn ] = await Enforcer(def, { fullResult: true, componentOptions: { exceptionEscalateCodes: ['WSCH005'] }})
+                expect(err).to.match(/Schemas with an indeterminable type/);
+                expect(warn).to.be.undefined;
             });
 
             it('requires a valid type', () => {
@@ -819,7 +846,7 @@ describe('definition/schema', () => {
                 });
 
                 it('handles nested allOf', () => {
-                    const [ schema ] = Enforcer.v2_0.Schema({
+                    const [ schema, err ] = Enforcer.v2_0.Schema({
                         allOf: [
                             {
                                 allOf: [

--- a/test/definition.schema.test.js
+++ b/test/definition.schema.test.js
@@ -198,7 +198,7 @@ describe('definition/schema', () => {
             expect(err).to.be.undefined;
         });
 
-        describe.only('type', () => {
+        describe('type', () => {
 
             it('will warn of the missing "type" property', () => {
                 const [ v, err, warn ] = Enforcer.v2_0.Schema({});

--- a/test/enforcer.parameter.test.js
+++ b/test/enforcer.parameter.test.js
@@ -163,11 +163,15 @@ describe('enforcer/parameter', () => {
                     in: 'query',
                     content: {
                         'application/json': {
-                            schema: {}
+                            schema: {
+                                minimum: 5,
+                                maximum: 10,
+                                default: 1
+                            }
                         }
                     }
                 });
-                expect(err).to.match(/Missing required property: type/);
+                expect(err).to.match(/Expected number to be greater than or equal to 5/);
             });
 
             it('can not set encoding for parameters', () => {
@@ -535,15 +539,6 @@ describe('enforcer/parameter', () => {
                 schema: []
             });
             expect(err).to.match(/at: schema\s+Value must be a plain object/);
-        });
-
-        it('must be a valid schema', () => {
-            const [ , err ] = Enforcer.v3_0.Parameter({
-                name: 'hi',
-                in: 'query',
-                schema: {}
-            });
-            expect(err).to.match(/at: schema/);
         });
 
         it('cannot accompany content property', () => {


### PR DESCRIPTION
Previous versions have required the `type` property to be specified for schemas (except in the case where one of `allOf`, `anyOf`, `oneOf`, and `not` are defined).
    
This update no longer requires `type` to be specified. If `type` is not specified then the OpenAPI Enforcer will attempt to auto determine type. If the type cannot be determined and should exist then warning `WSCH005` ("Schemas with an indeterminable type cannot serialize, deserialize, or validate values.") will be generated.