### PR TITLE
expose matched operations on validation errors

### DIFF
--- a/src/enforcers/OpenApi.js
+++ b/src/enforcers/OpenApi.js
@@ -81,12 +81,11 @@ module.exports = {
                 })
             }
 
-            if (exception.hasException) return new Result(undefined, exception);
             return new Result({
                 operation,
                 params,
                 pathKey: pathMatch.pathKey
-            });
+            }, exception);
         },
 
         /**

--- a/src/result.js
+++ b/src/result.js
@@ -32,7 +32,6 @@ function EnforcerResult(value, exception, warn) {
 
     if (!exception || !exception.hasException) exception = undefined;
     if (!warn || !warn.hasException) warn = undefined;
-    if (exception) value = undefined;
 
     this.error = exception;
     this.value = value;


### PR DESCRIPTION
Closes #95 

I have made a simple change which addresses the issue I'm having (#95) with getting operation info for a parameter validation error.