### PR TITLE
fix case when deserialize screw up example with oneOf/anyOf

### DIFF
--- a/src/schema/deserialize.js
+++ b/src/schema/deserialize.js
@@ -182,7 +182,6 @@ function runDeserialize(exception, map, schema, originalValue, options) {
             }
         }
 
-    } else {
-        return value;
     }
+    return value;
 }

--- a/test/definition.schema.test.js
+++ b/test/definition.schema.test.js
@@ -1656,6 +1656,71 @@ describe('definition/schema', () => {
 
         describe('oneOf', () => {
 
+            it('it does not screw up value when deserialize example', () => {
+                const [ schema, err, warn ] = Enforcer.v3_0.Schema({
+                    type: 'object',
+                    required: ['f'],
+                    properties: {
+                        'f': {
+                            type: 'array',
+                            items: {
+                                oneOf: [
+                                    {
+                                        type: 'object',
+                                        required: ['n', 'n1', 'v'],
+                                        properties: {
+                                            n: {
+                                                type: 'string',
+                                                enum: ['f1']
+                                            },
+                                            n1: {
+                                                type: 'string',
+                                            },
+                                            v: {
+                                                type: 'array',
+                                                items: {
+                                                    type: 'string'
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        type: 'object',
+                                        required: ['n', 'n1', 'v'],
+                                        properties: {
+                                            n: {
+                                                type: 'string',
+                                                enum: ['f2']
+                                            },
+                                            n1: {
+                                                type: 'number',
+                                            },
+                                            v: {
+                                                type: 'array',
+                                                items: {
+                                                    type: 'boolean'
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    example: {
+                        'f': [
+                            {
+                                n: 'f1',
+                                n1: "sdfs",
+                                v: ['one', 'two']
+                            }
+                        ]
+                    }
+                });
+                expect(err).to.be.undefined;
+                expect(warn).to.be.undefined;
+            });
+
             it('is not allowed for v2', () => {
                 const [ , err ] = Enforcer.v2_0.Schema({ oneOf: [] });
                 expect(err).to.match(/Property not allowed: oneOf/);


### PR DESCRIPTION
Hi, maybe you know better solution?)
Without fix i got something like:
```
EnforcerException: One or more warnings exist in the Schema definition
    at: example
      Invalid value
        at: f > 0
          Did not validate against exactly one schema
            at: 0
              Invalid value
                at: n1
                  Expected a string. Received: undefined
                at: v
                  at: 0
                    Expected a string. Received: undefined
                  at: 1
                    Expected a string. Received: undefined
```
What happends:
in schema utils lib try to get score of all possible variants
value differs by type
when lib deserialize with schema that have other type for field it screws up actual value with undefined (because deserialize return undefined on error)
after scoring lib try to validate screwed value against correct schema and it fails because value contains undefined