### PR TITLE
Fix Operation.response case-sensitive handling of headers

### DIFF
--- a/src/enforcers/Operation.js
+++ b/src/enforcers/Operation.js
@@ -420,18 +420,19 @@ module.exports = {
                 const headerKeys = Object.keys(headers);
                 if (response.headers) {
                     Object.keys(response.headers).forEach(key => {
+                        const lowerKey = key.toLowerCase();
                         const header = response.headers[key];
                         const schema = header.schema;
                         let value;
 
-                        if (headers.hasOwnProperty(key)) {
-                            value = headers[key];
+                        if (headers.hasOwnProperty(lowerKey)) {
+                            value = headers[lowerKey];
                         } else if (schema.hasOwnProperty('default')) {
                             value = util.copy(schema.default);
                         }
 
                         if (value !== undefined) {
-                            util.arrayRemoveItem(headerKeys, key);
+                            util.arrayRemoveItem(headerKeys, lowerKey);
                             value = schema.formalize(value);
                             let err = schema.validate(value);
                             if (!err) [value, err] = schema.serialize(value);

--- a/test/enforcer.operation.test.js
+++ b/test/enforcer.operation.test.js
@@ -2072,6 +2072,16 @@ describe('enforcer/operation', () => {
                     expect(err).to.match(/at: headers > color > x\s+Unable to stringify value/)
                 });
 
+                it('does not care about case of keys in headers object', () => {
+                    const operation = getOperationWithResponseHeader(3, {
+                        CaseInsensitive: {
+                            schema: { type: 'string' }
+                        }
+                    });
+                    const [ res ] = operation.response(200, '', { CASEInsensitive: 'success' });
+                    expect(res.headers['CaseInsensitive']).to.equal('success');
+                });
+
             });
 
         });


### PR DESCRIPTION
Operation.response fails to include headers from the supplied headers param unless the corresponding header names in the definition file are in all lowercase.  This PR fixes what I perceive to be the problem and it demonstrates the issue in the new test case.